### PR TITLE
make code forward-compatible for php7 (and still backward-compatible)

### DIFF
--- a/lib/Validations.php
+++ b/lib/Validations.php
@@ -577,7 +577,7 @@ class Validations
 		{
 			$options = array_merge($configuration, $attr);
 			$pk = $this->model->get_primary_key();
-			$pk_value = $this->model->$pk[0];
+			$pk_value = $this->model->{$pk[0]};
 
 			if (is_array($options[0]))
 			{


### PR DESCRIPTION
indirect access to variables is strictly evaluated left-to-right in php7
